### PR TITLE
Minor Makefile tweak, and added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*~
+\#*\#
+.\#*
+*.log
+freecell
+sol
+spider

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ sol: sol.c sol.h schemes.h
 	$(CC) $(CFLAGS) -DKLONDIKE $< -o $@
 
 spider: sol.c sol.h schemes.h
-	$(CC) $(CFLAGS) -DSPIDER sol.c -o $@
+	$(CC) $(CFLAGS) -DSPIDER $< -o $@
 
 freecell: sol.c sol.h schemes.h
-	$(CC) $(CFLAGS) -DFREECELL sol.c -o $@
+	$(CC) $(CFLAGS) -DFREECELL $< -o $@
 
 clean:
 	rm -f sol spider freecell


### PR DESCRIPTION
Two very minor changes that I have tested and confirm cause no functional changes:

1) Makefile cleanup in the 'spider:' and 'freecell:' targets.
2) New .gitignore to cause the 3 compiled binary targets, Emacs specific *~, #*#, and .#* files, and *.log files to be ignored by git.

Great work thus far.  I love the minimalism, and I hope to learn much from perusing the code. 